### PR TITLE
submodule coremark. clean git status after a build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+coremark.riscv

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "coremark"]
+	path = coremark
+	url = https://github.com/eembc/coremark

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This repository provides the utility files to port [CoreMark EEMBC](https://www.
 
 ### Setup
 
+  - `git submodule update --init`
   - Run the `./build-coremark.sh` script that does the following
     - Clones the [CoreMark repository](https://github.com/eembc/coremark) and checks out the hash found in `COREMARK_HASH`
     - Copies the `riscv64` repository to the `coremark` repo

--- a/build-coremark.sh
+++ b/build-coremark.sh
@@ -10,3 +10,5 @@ cd $BASEDIR/$CM_FOLDER
 # run the compile
 echo "Start compilation"
 make PORT_DIR=../riscv64 compile
+
+mv coremark.riscv ../

--- a/build-coremark.sh
+++ b/build-coremark.sh
@@ -5,24 +5,8 @@ set -e
 BASEDIR=$PWD
 CM_FOLDER=coremark
 
-# if not existing checkout the repository
-if [ ! -d "$BASEDIR/$CM_FOLDER" ]; then
-    echo "Cloning the CoreMark repository"
-    git clone https://github.com/eembc/coremark $BASEDIR/$CM_FOLDER
-fi
-
-# checkout the proper commit
 cd $BASEDIR/$CM_FOLDER
-echo "Checking out commit hash $(cat $BASEDIR/COREMARK_HASH)"
-git fetch
-git checkout $(cat $BASEDIR/COREMARK_HASH)
-
-# copy over the files if they are not already present
-if [ ! -d "riscv64" ]; then
-    echo "Copying defaults over"
-    cp -R $BASEDIR/riscv64 $BASEDIR/$CM_FOLDER
-fi
 
 # run the compile
 echo "Start compilation"
-make PORT_DIR=riscv64 compile
+make PORT_DIR=../riscv64 compile


### PR DESCRIPTION
I'm working on building a firesim workload for this and got dirty git status after running a build. 

This PR:
- submodules coremark with the correct HASH
- changes the build to point to the riscv64 dir rather than copying it
- moves the coremark.riscv dir back out to the top