### PR TITLE
Update to build optimized binaries by default

### DIFF
--- a/build-coremark.sh
+++ b/build-coremark.sh
@@ -14,3 +14,7 @@ mv coremark.riscv ../
 
 make PORT_DIR=../riscv64-baremetal compile
 mv coremark.bare.riscv ../
+
+cd $BASEDIR
+riscv64-unknown-elf-objdump -D coremark.riscv > coremark.riscv.dump
+riscv64-unknown-elf-objdump -D coremark.bare.riscv > coremark.bare.riscv.dump

--- a/riscv64-baremetal/core_portme.mak
+++ b/riscv64-baremetal/core_portme.mak
@@ -31,7 +31,7 @@ CC = $(RISCVTOOLS)/bin/$(RISCVTYPE)-gcc
 # Flag: CFLAGS
 #	Use this flag to define compiler options. Note, you can add compiler options from the command line using XCFLAGS="other flags"
 #PORT_CFLAGS = -O2 -static -std=gnu99
-PORT_CFLAGS = -O2 -mcmodel=medany -static -std=gnu99 -fno-common -nostdlib -nostartfiles -lm -lgcc -T $(PORT_DIR)/link.ld
+PORT_CFLAGS = -O2 -floop-unroll-and-jam -falign-loops=16 -falign-functions=16 -falign-jumps=16 -mtune=sifive-7-series -mcmodel=medany -static -std=gnu99 -fno-common -nostdlib -nostartfiles -lm -lgcc -T $(PORT_DIR)/link.ld
 FLAGS_STR = "$(PORT_CFLAGS) $(XCFLAGS) $(XLFLAGS) $(LFLAGS_END)"
 CFLAGS = $(PORT_CFLAGS) -I$(PORT_DIR) -I. -DFLAGS_STR=\"$(FLAGS_STR)\"
 #Flag: LFLAGS_END

--- a/riscv64/core_portme.mak
+++ b/riscv64/core_portme.mak
@@ -31,7 +31,7 @@ CC = $(RISCVTOOLS)/bin/$(RISCVTYPE)-gcc
 # Flag: CFLAGS
 #	Use this flag to define compiler options. Note, you can add compiler options from the command line using XCFLAGS="other flags"
 #PORT_CFLAGS = -O2 -static -std=gnu99
-PORT_CFLAGS = -O2
+PORT_CFLAGS = -O2 -floop-unroll-and-jam -falign-loops=16 -falign-functions=16 -falign-jumps=16 -mtune=sifive-7-series
 FLAGS_STR = "$(PORT_CFLAGS) $(XCFLAGS) $(XLFLAGS) $(LFLAGS_END)"
 CFLAGS = $(PORT_CFLAGS) -I$(PORT_DIR) -I. -DFLAGS_STR=\"$(FLAGS_STR)\"
 #Flag: LFLAGS_END


### PR DESCRIPTION
One day we will have `-mtune=boom`, for now `-mtune=sifive-7-series` is the right thing to use.