### PR TITLE
Baremetal patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ This repository provides the utility files to port [CoreMark EEMBC](https://www.
     - Builds a version of Coremark for Linux or pk (coremark.riscv)
     - Builds a version of Coremark for bare-metal (coremark.bare.riscv)
     - Copies the output binaries into this directory
-
+### Bare-metal core frequency
+  - To define the bare-metal core frequency, edit `BAREMETAL_CORE_FREQ` in `./riscv64-baremetal/core_portme.h`
+  - The default value has been set to 1Mhz to reduce execution time on spike and FPGAs.
 ### Default Files
 
 The default files target **RV64GC** and use minimal amount of compilation flags. Additionally, the `*.mak` file in the `riscv64`

--- a/riscv64-baremetal/core_portme.c
+++ b/riscv64-baremetal/core_portme.c
@@ -108,7 +108,7 @@ void portable_free(void *p) {
 	#define SAMPLE_TIME_IMPLEMENTATION 1
 #else
     // Defined for RISCV
-    #define NSECS_PER_SEC 1000000000 // TODO: What freq are we assuming?
+    #define NSECS_PER_SEC BAREMETAL_CORE_FREQ // Frequency defined in core_portme.h
 	#define EE_TIMER_TICKER_RATE 1000 // TODO: What is this?
 	#define CORETIMETYPE clock_t
     #define read_csr(reg) ({ unsigned long __tmp; \

--- a/riscv64-baremetal/core_portme.h
+++ b/riscv64-baremetal/core_portme.h
@@ -24,11 +24,18 @@ Original Author: Shay Gal-on
 /************************/
 /* Data types and settings */
 /************************/
+/* Configuration: Used or assumed core frequency in MHz
+	Must be low enough to run on spike or FPGAs.
+*/
+#ifndef BAREMETAL_CORE_FREQ
+#define BAREMETAL_CORE_FREQ 1000000		// 1 MHz
+#endif
+
 /* Configuration: HAS_FLOAT
 	Define to 1 if the platform supports floating point.
 */
 #ifndef HAS_FLOAT
-#define HAS_FLOAT 1
+#define HAS_FLOAT 0  // The used syscalls.c doesn't have float implemented. Coremark does not test float.
 #endif
 /* Configuration: HAS_TIME_H
 	Define to 1 if platform has the time.h header file,


### PR DESCRIPTION
Fixed:

- Allowing Coremark score to be printed by disabling HAS_FLOAT, because syscalls.c does not support float printf.

- Allowing user to define the bare-metal core frequency to reduce execution time on spike and FPGAs and get a Coremarks/sec result.